### PR TITLE
Fix examples

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,8 @@ classifiers=
 [options]
 zip_safe = True
 python_requires = >= 3.7
+package_dir =
+    = quantumflow
 packages = find:
 
 install_requires =
@@ -50,6 +52,10 @@ install_requires =
 
 setup_requires =
   setuptools_scm
+
+[options.packages.find]
+exclude = examples
+where = quantumflow
 
 [options.extras_require]
 ext =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,9 @@ classifiers=
     Topic :: Software Development :: Libraries
     Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7    
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9    
+    Programming Language :: Python :: 3.9
     Operating System :: OS Independent
 
 
@@ -41,7 +41,7 @@ install_requires =
     scipy
     sympy                   >= 1.6
     networkx
-    decorator               < 5.0.0     # 5.0 breaks networkx dependancy 
+    decorator               < 5.0.0     # 5.0 breaks networkx dependancy
     opt_einsum
     pillow
     matplotlib
@@ -52,14 +52,14 @@ setup_requires =
   setuptools_scm
 
 [options.extras_require]
-ext = 
+ext =
     cirq                    >= 0.8.0
     qiskit                  >= 0.24.0
     ruamel.yaml                         # Additional requirement for pyquil
     pyquil                  >= 2.28.0
     qsimcirq
     qutip
-    amazon-braket-sdk    
+    amazon-braket-sdk
 
 docs =
     sphinx
@@ -72,7 +72,7 @@ dev =
     qiskit                  >= 0.24.0
     ruamel.yaml
     pyquil                  >= 2.28.0
-    qsimcirq            
+    qsimcirq
     qutip
     amazon-braket-sdk
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,9 @@ setup_requires =
   setuptools_scm
 
 [options.packages.find]
-exclude = examples
+exclude =
+    examples
+    examples.*
 where = quantumflow
 
 [options.extras_require]


### PR DESCRIPTION
Currently, _examples_ is installed as a separate package as it doesn't live under the src dir. This PR should exclude it.

Note: This is guesswork though because I'm not sure why it's even included in the first place.

Closes #88